### PR TITLE
Upgrade keyboard visibility package

### DIFF
--- a/lib/middleware/window.dart
+++ b/lib/middleware/window.dart
@@ -1,10 +1,11 @@
 import 'package:flutter/material.dart' hide Overlay;
-import 'package:keyboard_visibility/keyboard_visibility.dart';
+import 'package:flutter_keyboard_visibility/flutter_keyboard_visibility.dart';
 import 'overlay.dart';
 import 'scope.dart';
 import 'utils.dart';
 
 class Window {
+  KeyboardVisibilityController _keyboardVisibilityController;
   Scope _scope;
   Overlay _overlay;
   bool _isKeyboardActive;
@@ -13,17 +14,16 @@ class Window {
   Window(Scope scope) {
     _scope = scope;
     _overlay = Overlay(navigationDefaultFill: scope.application.settings.colors.navigation);
+    _keyboardVisibilityController = KeyboardVisibilityController();
     this.update(context: context);
   }
 
   Window update({BuildContext context, BoxConstraints constraints}) {
-    KeyboardVisibilityNotification().addNewListener(
-      onChange: (bool visible) {
-        _isKeyboardActive = visible;
-        _scope.alerts.dispose(quick: true);
-        _scope.rasterize();
-      },
-    );
+    _keyboardVisibilityController.onChange.listen((bool visible) {
+      _isKeyboardActive = visible;
+      _scope.alerts.dispose(quick: true);
+      _scope.rasterize();
+    });
 
     _available = constraints != null ? Size(constraints.maxWidth, constraints.maxHeight + (insets?.bottom ?? 0)) : size;
     return this;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -28,7 +28,14 @@ packages:
       name: camera
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.5.8+11"
+    version: "0.7.0+2"
+  camera_platform_interface:
+    dependency: transitive
+    description:
+      name: camera_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.5.0"
   characters:
     dependency: transitive
     description:
@@ -64,6 +71,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.0.3"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.0"
   crypto:
     dependency: transitive
     description:
@@ -216,6 +230,27 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.0"
+  flutter_keyboard_visibility:
+    dependency: "direct main"
+    description:
+      name: flutter_keyboard_visibility
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.0.6"
+  flutter_keyboard_visibility_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_keyboard_visibility_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.1"
+  flutter_keyboard_visibility_web:
+    dependency: transitive
+    description:
+      name: flutter_keyboard_visibility_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.1"
   flutter_localizations:
     dependency: "direct main"
     description: flutter
@@ -289,13 +324,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.6.2"
-  keyboard_visibility:
-    dependency: "direct main"
-    description:
-      name: keyboard_visibility
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.5.6"
   matcher:
     dependency: transitive
     description:
@@ -400,7 +428,7 @@ packages:
       name: plugin_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.3"
   process:
     dependency: transitive
     description:
@@ -421,7 +449,7 @@ packages:
       name: pull_to_refresh
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.0"
+    version: "1.6.3"
   qr:
     dependency: transitive
     description:
@@ -442,7 +470,7 @@ packages:
       name: quiver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.3"
+    version: "2.1.5"
   shared_preferences:
     dependency: "direct main"
     description:
@@ -518,6 +546,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.9.3"
+  stream_transform:
+    dependency: transitive
+    description:
+      name: stream_transform
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.2.0"
   string_scanner:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   android_middleware:
     path: plugins/android_middleware
   cupertino_icons: ^0.1.3
-  keyboard_visibility: ^0.5.6
+  flutter_keyboard_visibility: ^4.0.6
   after_init: ^0.1.2
   flutter_icons: ^1.1.0
   camera: ^0.7.0+2


### PR DESCRIPTION
The current package seems to be outdate and no longer maintain.

[flutter_keyboard_visibility](https://pub.dev/packages/flutter_keyboard_visibility) is the better fork available

Please test it carefully as I only checked for my use case.