### PR TITLE
Add isList to Data class

### DIFF
--- a/lib/middleware/data.dart
+++ b/lib/middleware/data.dart
@@ -49,6 +49,10 @@ class Data {
     return Data(toObjects());
   }
 
+  bool isList() {
+    return _items is List;
+  }
+
   void $print() {
     final pattern = RegExp('.{1,800}');
     pattern.allMatches(toJson(pretty: true)).forEach((match) => print(match.group(0)));


### PR DESCRIPTION
Sometimes the API can return an array, sometimes can return a JSON.
Currently, there's no way to know. If you try to validate if
a property is null it will raise an exception if _items is not a map
i.e in  case of a list.