### PR TITLE
Add flexible button text

### DIFF
--- a/lib/widgets/buttons/text.dart
+++ b/lib/widgets/buttons/text.dart
@@ -210,10 +210,10 @@ class _TextButtonState extends State<TextButton> {
                                     size: widget.iconSize != null ? widget.iconSize : 20,
                                   ),
                                 ),
-                                Text(
+                                Flexible(child: Text(
                                   widget.caption,
                                   style: textStyle,
-                                ),
+                                )),
                               ],
                       )
                     : Text(


### PR DESCRIPTION
If the name of the button it's too large and the screen size
it's too small it will overflow between the boundaries of the
button itself. This can't be customize on the parent widget.