### PR TITLE
Add flexible to menu item in navigator

### DIFF
--- a/lib/middleware/navigator.dart
+++ b/lib/middleware/navigator.dart
@@ -179,7 +179,7 @@ class Navigator {
               size: 25.0 * ($item.iconScale ?? 1),
             ),
           ),
-          Column(
+          Flexible(child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: <Widget>[
               Text($item.caption(), style: $itemStyle),
@@ -196,7 +196,7 @@ class Navigator {
                     )
                   : Container()
             ],
-          ),
+          )),
         ],
       ),
     );


### PR DESCRIPTION
If the caption of the menu item is too large, it will
overflow between the boundaries of the available space.
Add flexible to wrap it into another line.