### PR TITLE
Fix issue with list view widget unmounted items

### DIFF
--- a/lib/middleware/form.dart
+++ b/lib/middleware/form.dart
@@ -144,7 +144,7 @@ class FieldsForm {
   bool validate({bool showMessage, bool autoFocus}) {
     var result = true;
     for (var field in fields.values) {
-      if (field.context != null) {
+      if (field.mounted && field.context != null) {
         if (field.validate(showMessage: showMessage) != null) {
           if (autoFocus != false) {
             field.focus();


### PR DESCRIPTION
When the items rendered on top of a huge list are hidden
on the current view (scroll down), it was failing to validate
the form if the items on top are hidden.