### PR TITLE
Add ability to use the full url instead of the hardcoded one

### DIFF
--- a/lib/helpers/document.dart
+++ b/lib/helpers/document.dart
@@ -291,7 +291,7 @@ class _DocumentState extends View<DocumentView, Application> {
 
     var $name = widget.title;
     var $filePath = '${cacheDirectory.path}/${$name}';
-    var $url = '${widget.file.url}/open';
+    var $url = widget.file.useFullUrl ? '${widget.file.url}' : '${widget.file.url}/open';
 
     try {
       await scope.api.download(

--- a/lib/widgets/fields/file.dart
+++ b/lib/widgets/fields/file.dart
@@ -14,12 +14,13 @@ import 'package:path/path.dart';
 import 'package:photo_view/photo_view.dart';
 
 class FileInputValue {
-  FileInputValue({this.url, this.path, this.title, this.extension});
+  FileInputValue({this.url, this.path, this.title, this.extension, this.useFullUrl=false});
 
   String url;
   String path;
   String title;
   String extension;
+  bool useFullUrl;
 
   bool get isImage => ['jpg', 'png', 'jpeg'].contains(extension);
 }


### PR DESCRIPTION
When you have querystring in the URL you can't use the default one.
I leaved the default one to avoid breaking any implementation
using it.